### PR TITLE
ci: bump actions/checkout from v3 to v5

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -24,7 +24,7 @@ jobs:
       HAS_SSH_KEY: ${{ secrets.SSH_KEY != '' }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
 
     # install build tools
     - name: Install build tools
@@ -111,7 +111,7 @@ jobs:
       run: |
         icacls . /inheritance:r
         icacls . /grant Administrators:F
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
 
     # install cygwin and build tools
     - name: Install Cygwin


### PR DESCRIPTION
I have carried the v3->v4 patch in Git for Windows for quite a while already; The main reason for contributing this now, though, is to verify that [GitGitGadget](https://gitgitgadget.github.io/) can be used to submit Cygwin patches, too, not only Git patches.