### PR TITLE
Cygwin: symlink_native: allow linking to `.` again

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1895,7 +1895,10 @@ symlink_native (const char *oldpath, path_conv &win32_newpath)
 	    e_old = wcpcpy (e_old, L"..\\"), num--;
 	  if (num > 0)
 	    e_old = wcpcpy (e_old, L"..");
-	  wcpcpy (e_old, c_old);
+	  if (e_old == final_oldpath->Buffer && c_old[0] == L'\0')
+	    wcpcpy (e_old, L".");
+	  else
+	    wcpcpy (e_old, c_old);
 	}
     }
   /* If the symlink target doesn't exist, don't create native symlink.


### PR DESCRIPTION
This fixes a regression I introduced in 827743ab76 (Cygwin: symlink_native: allow linking to `..`, 2025-06-20). It is not necessarily a _complete_ fix per se, but more a band-aid for the time being.