### PR TITLE
Mention the extremely useful small_printf() function

### DIFF
--- a/winsup/cygwin/DevDocs/how-to-debug-cygwin.txt
+++ b/winsup/cygwin/DevDocs/how-to-debug-cygwin.txt
@@ -126,3 +126,14 @@ set CYGWIN_DEBUG=cat.exe:gdb.exe
    program will crash, probably in small_printf.  At that point, a 'bt'
    command should show you the offending call to strace_printf with the
    improper format string.
+
+9. Debug output without strace
+
+   If you cannot use gdb, or if the program behaves differently using strace
+   for whatever reason, you can still use the small_printf() function to
+   output debugging messages directly to stderr.
+
+   This function accepts slightly different format placeholders than the
+   POSIX printf() function you're used to, for example `%W` instead of `%ls`
+   to print UTF-16 strings (provided via `wchar_t *` pointers). For full
+   details, see the first comment in `winsup/cygwin/smallprint.cc`.


### PR DESCRIPTION
I have been using this function many times for debugging over the years, and found that it was too hard to find originally.

Changes since v1 (which did not make it to the list for technical reasons that should be resolved by now):

- Extend the comment about to talk about slight deviations from the POSIX `printf()` function family.
- Improve on the commit message which previously was too terse.

cc: Jon Turney <jon.turney@dronecode.org.uk>