### PR TITLE
Fix stdio with app execution aliases (Microsoft Store applications)

### DIFF
--- a/winsup/cygwin/fhandler/termios.cc
+++ b/winsup/cygwin/fhandler/termios.cc
@@ -711,6 +711,15 @@ is_console_app (path_conv &pc)
   wchar_t *e = wcsrchr (native_path, L'.');
   if (e && (wcscasecmp (e, L".bat") == 0 || wcscasecmp (e, L".cmd") == 0))
     return true;
+
+  if (pc.is_app_execution_alias ())
+    {
+      UNICODE_STRING upath;
+      RtlInitUnicodeString (&upath, native_path);
+      path_conv target (&upath, PC_SYM_FOLLOW);
+      target.get_wide_win32_path (native_path);
+    }
+
   HANDLE h;
   h = CreateFileW (native_path, GENERIC_READ, FILE_SHARE_READ,
 		   NULL, OPEN_EXISTING, 0, NULL);

--- a/winsup/cygwin/fhandler/termios.cc
+++ b/winsup/cygwin/fhandler/termios.cc
@@ -704,6 +704,9 @@ fhandler_termios::fstat (struct stat *buf)
 static bool
 is_console_app (const WCHAR *filename)
 {
+  wchar_t *e = wcsrchr (filename, L'.');
+  if (e && (wcscasecmp (e, L".bat") == 0 || wcscasecmp (e, L".cmd") == 0))
+    return true;
   HANDLE h;
   h = CreateFileW (filename, GENERIC_READ, FILE_SHARE_READ,
 		   NULL, OPEN_EXISTING, 0, NULL);
@@ -720,9 +723,6 @@ is_console_app (const WCHAR *filename)
   IMAGE_NT_HEADERS32 *p = (IMAGE_NT_HEADERS32 *) memmem (buf, n, "PE\0\0", 4);
   if (p && (char *) &p->OptionalHeader.DllCharacteristics <= buf + n)
     return p->OptionalHeader.Subsystem == IMAGE_SUBSYSTEM_WINDOWS_CUI;
-  wchar_t *e = wcsrchr (filename, L'.');
-  if (e && (wcscasecmp (e, L".bat") == 0 || wcscasecmp (e, L".cmd") == 0))
-    return true;
   /* Return true for unknown to avoid standard handles from being unset.
      Setting-up standard handles for GUI apps is pointless, but not unsafe. */
   return true;

--- a/winsup/cygwin/fhandler/termios.cc
+++ b/winsup/cygwin/fhandler/termios.cc
@@ -707,10 +707,14 @@ is_console_app (const WCHAR *filename)
   HANDLE h;
   h = CreateFileW (filename, GENERIC_READ, FILE_SHARE_READ,
 		   NULL, OPEN_EXISTING, 0, NULL);
+  if (h == INVALID_HANDLE_VALUE)
+    return true;
   char buf[1024];
   DWORD n;
-  ReadFile (h, buf, sizeof (buf), &n, 0);
+  BOOL res = ReadFile (h, buf, sizeof (buf), &n, 0);
   CloseHandle (h);
+  if (!res)
+    return true;
   /* The offset of Subsystem is the same for both IMAGE_NT_HEADERS32 and
      IMAGE_NT_HEADERS64, so only IMAGE_NT_HEADERS32 is used here. */
   IMAGE_NT_HEADERS32 *p = (IMAGE_NT_HEADERS32 *) memmem (buf, n, "PE\0\0", 4);

--- a/winsup/cygwin/fhandler/termios.cc
+++ b/winsup/cygwin/fhandler/termios.cc
@@ -719,7 +719,9 @@ is_console_app (const WCHAR *filename)
   wchar_t *e = wcsrchr (filename, L'.');
   if (e && (wcscasecmp (e, L".bat") == 0 || wcscasecmp (e, L".cmd") == 0))
     return true;
-  return false;
+  /* Return true for unknown to avoid standard handles from being unset.
+     Setting-up standard handles for GUI apps is pointless, but not unsafe. */
+  return true;
 }
 
 int

--- a/winsup/cygwin/local_includes/fhandler.h
+++ b/winsup/cygwin/local_includes/fhandler.h
@@ -2035,7 +2035,7 @@ class fhandler_termios: public fhandler_base
     spawn_worker () :
       ptys_need_cleanup (false), cons_need_cleanup (false),
       stdin_is_ptys (false), ptys_ttyp (NULL) {}
-    void setup (bool iscygwin, HANDLE h_stdin, const WCHAR *runpath,
+    void setup (bool iscygwin, HANDLE h_stdin, path_conv &pc,
 		bool nopcon, bool reset_sendsig, const WCHAR *envblock);
     bool need_cleanup () { return ptys_need_cleanup || cons_need_cleanup; }
     void cleanup ();

--- a/winsup/cygwin/local_includes/path.h
+++ b/winsup/cygwin/local_includes/path.h
@@ -79,6 +79,7 @@ enum path_types
   PATH_SOCKET		= _BIT ( 5),	/* AF_UNIX socket file */
   PATH_RESOLVE_PROCFD	= _BIT ( 6),	/* fd symlink via /proc */
   PATH_REP_NOAPI	= _BIT ( 7),	/* rep. point unknown to WinAPI */
+  PATH_APPEXECLINK	= _BIT ( 8),	/* rep. point app execution alias */
   PATH_DONT_USE		= _BIT (31)	/* conversion to signed happens. */
 };
 
@@ -213,6 +214,10 @@ class path_conv
   int is_winapi_reparse_point () const
   {
     return (path_flags & (PATH_REP | PATH_REP_NOAPI)) == PATH_REP;
+  }
+  int is_app_execution_alias () const
+  {
+    return path_flags & PATH_APPEXECLINK;
   }
 
   int isfifo () const {return dev.is_device (FH_FIFO);}

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -2661,7 +2661,7 @@ check_reparse_point_target (HANDLE h, bool remote, PREPARSE_DATA_BUFFER rp,
 	  if (i == 2 && n > 0 && n < size)
 	    {
 	      RtlInitCountedUnicodeString (psymbuf, buf, n * sizeof (WCHAR));
-	      return PATH_SYMLINK | PATH_REP;
+	      return PATH_SYMLINK | PATH_REP | PATH_APPEXECLINK;
 	    }
 	  if (i == 2)
 	    break;

--- a/winsup/cygwin/spawn.cc
+++ b/winsup/cygwin/spawn.cc
@@ -579,7 +579,7 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
 
       bool no_pcon = mode != _P_OVERLAY && mode != _P_WAIT;
       term_spawn_worker.setup (iscygwin (), handle (fileno_stdin, false),
-			       runpath, no_pcon, reset_sendsig, envblock);
+			       real_path, no_pcon, reset_sendsig, envblock);
 
       /* Set up needed handles for stdio */
       si.dwFlags = STARTF_USESTDHANDLES;


### PR DESCRIPTION
When I introduced support for executing Microsoft Store applications through their "app execution aliases" (i.e. special reparse points installed into `%LOCALAPPDATA%\Microsoft\WindowsApps`) in https://inbox.sourceware.org/cygwin-patches/cover.1616428114.git.johannes.schindelin@gmx.de/, I had missed that it failed to spawn the process with the correct handles to the terminal, breaking interactive usage of, say, the Python interpreter.

This was later reported in https://inbox.sourceware.org/cygwin/CAAM_cieBo_M76sqZMGgF+tXxswvT=jUHL_pShff+aRv9P1Eiug@mail.gmail.com/t/#u, and also in https://github.com/python/pymanager/issues/210 (which was then re-reported in https://github.com/msys2/MSYS2-packages/issues/1943#issuecomment-3467583078).

The root cause is that the `is_console_app()` function required quite a bit of TLC, which this here patch series tries to provide.

Changes since v1:

- Amended the commit messages with "Fixes:" footers.
- Added a code comment to `is_console_app()` to clarify why a simple `CreateFile()` is not enough in the case of app execution aliases.

Cc: Cody Tapscott <cody@tapscott.me>
cc: Corinna Vinschen <corinna-cygwin@cygwin.com>
cc: Takashi Yano <takashi.yano@nifty.ne.jp>
cc: Richard Campbell <richard.u.campbell@gmail.com>