### PR TITLE
Fix out-of-order keystrokes

### DIFF
--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -2186,21 +2186,6 @@ fhandler_pty_master::write (const void *ptr, size_t len)
       if (!get_ttyp ()->pcon_start)
 	{ /* Pseudo console initialization has been done in above code. */
 	  pinfo pp (get_ttyp ()->pcon_start_pid);
-	  if (get_ttyp ()->switch_to_nat_pipe
-	      && get_ttyp ()->pty_input_state_eq (tty::to_cyg))
-	    {
-	      /* This accept_input() call is needed in order to transfer input
-		 which is not accepted yet to non-cygwin pipe. */
-	      WaitForSingleObject (input_mutex, mutex_timeout);
-	      if (get_readahead_valid ())
-		accept_input ();
-	      acquire_attach_mutex (mutex_timeout);
-	      fhandler_pty_slave::transfer_input (tty::to_nat, from_master,
-						  get_ttyp (),
-						  input_available_event);
-	      release_attach_mutex ();
-	      ReleaseMutex (input_mutex);
-	    }
 	  get_ttyp ()->pcon_start_pid = 0;
 	}
 

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -489,6 +489,7 @@ fhandler_pty_master::accept_input ()
   HANDLE write_to = get_output_handle ();
   tmp_pathbuf tp;
   if (to_be_read_from_nat_pipe ()
+      && !get_ttyp ()->pcon_activated
       && get_ttyp ()->pty_input_state == tty::to_nat)
     {
       /* This code is reached if non-cygwin app is foreground and
@@ -2208,8 +2209,18 @@ fhandler_pty_master::write (const void *ptr, size_t len)
   WaitForSingleObject (input_mutex, mutex_timeout);
   if (to_be_read_from_nat_pipe () && get_ttyp ()->pcon_activated
       && get_ttyp ()->pty_input_state == tty::to_nat)
-    { /* Reaches here when non-cygwin app is foreground and pseudo console
-	 is activated. */
+    {
+      /* Flush any stale readahead data from a prior line_edit call that
+	 ran while pty_input_state was temporarily to_cyg (e.g. during a
+	 setpgid_aux transition when a cygwin child of the native process
+	 started or exited).  Without this, the readahead contents would
+	 be stranded and emitted after the direct WriteFile below,
+	 breaking chronological order. */
+      if (get_readahead_valid ())
+	{
+	  accept_input ();
+	}
+
       tmp_pathbuf tp;
       char *buf = (char *) ptr;
       size_t nlen = len;

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -1171,12 +1171,23 @@ fhandler_pty_slave::reset_switch_to_nat_pipe (void)
   DWORD wait_ret = WaitForSingleObject (pipe_sw_mutex, mutex_timeout);
   if (wait_ret == WAIT_TIMEOUT)
     return;
-  if (!nat_pipe_owner_self (get_ttyp ()->nat_pipe_owner_pid)
-      && process_alive (get_ttyp ()->nat_pipe_owner_pid))
+  if (process_alive (get_ttyp ()->nat_pipe_owner_pid))
     {
-      /* There is a process which owns nat pipe. */
-      ReleaseMutex (pipe_sw_mutex);
-      return;
+      if (!nat_pipe_owner_self (get_ttyp ()->nat_pipe_owner_pid))
+	{
+	  /* There is a process which owns nat pipe. */
+	  ReleaseMutex (pipe_sw_mutex);
+	  return;
+	}
+      /* We are the nat pipe owner.  Don't reset while a native process
+	 is still using the nat pipe -- check both pcon_activated and
+	 switch_to_nat_pipe since the latter stays true during pcon
+	 handovers when pcon_activated is briefly false. */
+      if (get_ttyp ()->pcon_activated || get_ttyp ()->switch_to_nat_pipe)
+	{
+	  ReleaseMutex (pipe_sw_mutex);
+	  return;
+	}
     }
   /* Clean up nat pipe state */
   get_ttyp ()->pty_input_state = tty::to_cyg;

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -2250,17 +2250,6 @@ fhandler_pty_master::write (const void *ptr, size_t len)
      or cygwin process is foreground even though pseudo console is
      activated. */
 
-  /* This input transfer is needed when cygwin-app which is started from
-     non-cygwin app is terminated if pseudo console is disabled. */
-  if (to_be_read_from_nat_pipe () && !get_ttyp ()->pcon_activated
-      && get_ttyp ()->pty_input_state == tty::to_cyg)
-    {
-      acquire_attach_mutex (mutex_timeout);
-      fhandler_pty_slave::transfer_input (tty::to_nat, from_master,
-					  get_ttyp (), input_available_event);
-      release_attach_mutex ();
-    }
-
   line_edit_status status = line_edit (p, len, ti, &ret);
   ReleaseMutex (input_mutex);
 


### PR DESCRIPTION
A Git for Windows user reported that typing in a Bash session while a native Windows program is running (or has just exited) can produce scrambled input -- e.g. typing "git log" yields "igt olg": https://github.com/git-for-windows/git/issues/5632

I have been experiencing what I suspect is the same bug for a long time in my `tmux` sessions: after quitting a pager and immediately pressing cursor-up to recall the previous command, often followed by Escape+Backspace, the Bash session simply hangs. I suspect that the escape sequence bytes arrive out of order, and hence the sequence does not parse, and the terminal hangs. Quite frustrating, and it happens often enough to be a real productivity drain.

This bug report was therefore always on my mind, and gaining some good experience with AI-assisted coding at work finally gave me the push to investigate properly. I started by writing an AutoHotKey-based UI test (Git for Windows has a small suite of those; they are not included in this series because they are specific to our fork). Getting a reliable reproducer required quite a bit of back-and-forth as the bug is timing-sensitive and only manifests when pseudo console transitions happen while keystrokes are in flight.

The investigation itself was substantial. The total session spread over a week. To be transparent about the methodology: I used AI (Claude Opus) as an investigative tool throughout this process. I dictated context and direction via speech recognition, the AI searched the code, instrumented the code _liberally_, and dug into the PTY internals. Every decision about what to investigate, what to fix and how was mine, the AI merely executed my plans. I typed very little (leaving typing to Parakeet's speech recognition and to Claude Opus); the keystrokes are not mine, but the ideas are. For that reason I use "Assisted-by" rather than "Co-authored-by" trailers in the commits.

The root cause is what Opus labeled "pseudo console oscillation" (I called it "flickering" but agree that "oscillation" is a better term): each time a native program starts or exits, `pcon_activated` and `pty_input_state` change rapidly, and several code paths in `master::write()` react by calling `transfer_input()` to move data between the `cyg` and `nat` pipes. During oscillation, these transfers steal readline's buffered data from the `cyg` pipe, causing characters to arrive out of order.

My suspicion is that the originally reported bug is fixed entirely by the first patch (1/4). The remaining three address edge cases that the reproducer exposed through its more aggressive oscillation pattern. You might say that I over-deliver a bit, but that seems like a good thing in this instance.

I tested both with and without `MSYS=disable_pcon` to verify that the scenarios the removed code was originally intended to handle are still covered by `setpgid_aux()`. This is even automated in Git for Windows' fork via the AutoHotKey-based tests; for full details see https://github.com/git-for-windows/msys2-runtime/pull/124.

cc: Takashi Yano <takashi.yano@nifty.ne.jp>